### PR TITLE
V0.8.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.8.2
+
+* Migrate from the deprecated original Android Support Library to AndroidX. This shouldn't result in any functional changes, but it requires any Android apps using this plugin to also migrate if they're using the original support library.
+* Update url_launcher plugin
+* Fix snack bar problem when icon is visible
+
 ## 0.8.1
 
 * Fixed some bugs of EventBus

--- a/example/lib/sample/sample_floating_action_button.dart
+++ b/example/lib/sample/sample_floating_action_button.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:scaffold_factory/scaffold_factory.dart';
 

--- a/lib/scaffold_factory.dart
+++ b/lib/scaffold_factory.dart
@@ -446,13 +446,10 @@ class ScaffoldFactory {
             content: Directionality(
               textDirection: textDirection,
               child: iconVisibility
-                  ? Row(
-                      mainAxisSize: MainAxisSize.min,
-                      children: <Widget>[
-                        Icon(icon, color: iconColor),
-                        SizedBox(width: 4.0),
-                        text,
-                      ],
+                  ? ListTile(
+                      contentPadding: EdgeInsets.all(0),
+                      leading: Icon(icon, color: iconColor),
+                      title: text,
                     )
                   : text,
             ),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: scaffold_factory
 description: A Flutter plugin to build and customize the Flutter's scaffold widget with simple and flexible configurations.
-version: 0.8.1
+version: 0.8.2
 author: Erfan Jazeb Nikoo <erfan.jazebnikoo@gmail.com>
 homepage: https://github.com/erfanjazebnikoo/scaffold_factory
 
@@ -12,7 +12,7 @@ dependencies:
     sdk: flutter
   flutter_statusbarcolor: ^0.1.1
   event_bus: ^1.0.1
-  url_launcher: ^4.0.1
+  url_launcher: ^5.0.2
 
 # The following section is specific to Flutter.
 flutter:


### PR DESCRIPTION
Changes:

 - Migrate from the deprecated original Android Support Library to AndroidX. This shouldn't result in any functional changes, but it requires any Android apps using this plugin to also migrate if they're using the original support library.
 - Update url_launcher plugin
 - Fix snack bar problem when icon is visible